### PR TITLE
Feat: 갤러리 사진 게시글 페이지네이션 기능 추가

### DIFF
--- a/src/main/java/com/sparta/finalproject/domain/gallery/controller/ImagePostController.java
+++ b/src/main/java/com/sparta/finalproject/domain/gallery/controller/ImagePostController.java
@@ -29,12 +29,21 @@ public class ImagePostController {
         return imagePostService.getImagePost(imagePostId);
     }
 
+//    @GetMapping("api/common/classes/{classroomId}/gallery")
+//    public ResponseEntity<List<ImagePostResponseDto>> readImagePostList(@PathVariable Long classroomId,
+//                                                                        @RequestParam(required = false, defaultValue = "2000-01-01", value = "start") String startDate,
+//                                                                        @RequestParam(required = false, defaultValue = "3000-01-01", value = "end") String endDate,
+//                                                                        @RequestParam(required = false, defaultValue = "", value = "keyword") String keyword) {
+//        return imagePostService.getImagePostListByCriteria(classroomId, startDate, endDate, keyword);
+//    }
     @GetMapping("api/common/classes/{classroomId}/gallery")
-    public ResponseEntity<List<ImagePostResponseDto>> readImagePostList(@PathVariable Long classroomId,
+    public ResponseEntity<List<ImagePostResponseDto>> readImagePostPage(@PathVariable Long classroomId,
                                                                         @RequestParam(required = false, defaultValue = "2000-01-01", value = "start") String startDate,
                                                                         @RequestParam(required = false, defaultValue = "3000-01-01", value = "end") String endDate,
-                                                                        @RequestParam(required = false, defaultValue = "", value = "keyword") String keyword) {
-        return imagePostService.getImagePostListByCriteria(classroomId, startDate, endDate, keyword);
+                                                                        @RequestParam(required = false, defaultValue = "", value = "keyword") String keyword,
+                                                                        @RequestParam(required = false, defaultValue = "1", value = "page") int page,
+                                                                        @RequestParam(required = false, defaultValue = "0", value = "isAsc") boolean isAsc) {
+        return imagePostService.getImagePostPage(classroomId,startDate, endDate, keyword, page, isAsc);
     }
 
     @DeleteMapping("api/managers/image-posts/{imagePostId}")

--- a/src/main/java/com/sparta/finalproject/domain/gallery/repository/ImagePostRepository.java
+++ b/src/main/java/com/sparta/finalproject/domain/gallery/repository/ImagePostRepository.java
@@ -1,11 +1,13 @@
 package com.sparta.finalproject.domain.gallery.repository;
 
 import com.sparta.finalproject.domain.gallery.entity.ImagePost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
-import java.util.List;
 
 public interface ImagePostRepository extends JpaRepository<ImagePost, Long> {
-    List<ImagePost> findAllByClassroomIdAndCreatedAtBetweenOrderByIdDesc(Long id, LocalDate startDate, LocalDate endDate);
+//    List<ImagePost> findAllByClassroomIdAndCreatedAtBetweenOrderByIdDesc(Long id, LocalDate startDate, LocalDate endDate);
+    Page<ImagePost> findAllByClassroomIdAndTitleIsContainingAndCreatedAtBetween(Long id, String keyword, LocalDate startDate, LocalDate endDate, Pageable pageable);
 }


### PR DESCRIPTION
## 📕 갤러리 사진 게시글 페이지네이션 기능 추가

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 한 페이지 당 15개의 사진 게시글을 반환

## 📘 PR 특이 사항
관련 이슈 번호 : #19 