### PR TITLE
Feat: 관리자 페이지 기능 구현

### DIFF
--- a/src/main/java/com/sparta/finalproject/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/sparta/finalproject/domain/attendance/controller/AttendanceController.java
@@ -3,10 +3,7 @@ package com.sparta.finalproject.domain.attendance.controller;
 import com.sparta.finalproject.domain.attendance.service.AttendanceService;
 import com.sparta.finalproject.global.dto.GlobalResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,18 +17,18 @@ public class AttendanceController {
         return "성공";
     }
 
-    @PatchMapping("api/managers/attendance/enter")
-    public GlobalResponseDto modifyChildEnter(@RequestParam(value = "childId") Long childId) {
+    @PutMapping("manager/child/{childId}/enter")
+    public GlobalResponseDto modifyChildEnter(@PathVariable Long childId) {
         return attendanceService.childEnterModify(childId);
     }
 
-    @PatchMapping("api/managers/attendance/exit")
-    public GlobalResponseDto modifyChildExit(@RequestParam(value = "childId") Long childId) {
+    @PutMapping("manager/child/{childId}/exit")
+    public GlobalResponseDto modifyChildExit(@PathVariable Long childId) {
         return attendanceService.childExitModify(childId);
     }
 
-    @PatchMapping("api/managers/attendance/absent")
-    public GlobalResponseDto modifyChildAbsent(@RequestParam(value = "childId") Long childId) {
-        return attendanceService.childAbsentModify(childId);
-    }
+//    @PutMapping("api/managers/attendance/absent")
+//    public GlobalResponseDto modifyChildAbsent(@RequestParam(value = "childId") Long childId) {
+//        return attendanceService.childAbsentModify(childId);
+//    }
 }

--- a/src/main/java/com/sparta/finalproject/domain/attendance/dto/AbsentResponseDto.java
+++ b/src/main/java/com/sparta/finalproject/domain/attendance/dto/AbsentResponseDto.java
@@ -4,9 +4,6 @@ import com.sparta.finalproject.domain.attendance.entity.Attendance;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor
@@ -15,10 +12,8 @@ public class AbsentResponseDto {
     private Long childId;
     private String name;
     private boolean isAbsent;
-    @DateTimeFormat(pattern = "HH:mm")
-    private LocalTime dailyEnterTime;
-    @DateTimeFormat(pattern = "HH:mm")
-    private LocalTime dailyExitTime;
+    private String dailyEnterTime;
+    private String dailyExitTime;
 
 
     @Builder

--- a/src/main/java/com/sparta/finalproject/domain/attendance/dto/EnterResponseDto.java
+++ b/src/main/java/com/sparta/finalproject/domain/attendance/dto/EnterResponseDto.java
@@ -4,9 +4,6 @@ import com.sparta.finalproject.domain.attendance.entity.Attendance;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor
@@ -15,10 +12,8 @@ public class EnterResponseDto {
     private Long childId;
     private String name;
     private boolean isEntered;
-    @DateTimeFormat(pattern = "HH:mm")
-    private LocalTime dailyEnterTime;
-    @DateTimeFormat(pattern = "HH:mm")
-    private LocalTime dailyExitTime;
+    private String dailyEnterTime;
+    private String dailyExitTime;
 
     @Builder
     private EnterResponseDto (Attendance attendance) {

--- a/src/main/java/com/sparta/finalproject/domain/attendance/dto/ExitResponseDto.java
+++ b/src/main/java/com/sparta/finalproject/domain/attendance/dto/ExitResponseDto.java
@@ -4,9 +4,6 @@ import com.sparta.finalproject.domain.attendance.entity.Attendance;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor
@@ -15,10 +12,8 @@ public class ExitResponseDto {
     private Long childId;
     private String name;
     private boolean isExited;
-    @DateTimeFormat(pattern = "HH:mm")
-    private LocalTime dailyEnterTime;
-    @DateTimeFormat(pattern = "HH:mm")
-    private LocalTime dailyExitTime;
+    private String dailyEnterTime;
+    private String dailyExitTime;
 
     @Builder
     private ExitResponseDto (Attendance attendance) {

--- a/src/main/java/com/sparta/finalproject/domain/attendance/entity/Attendance.java
+++ b/src/main/java/com/sparta/finalproject/domain/attendance/entity/Attendance.java
@@ -22,20 +22,20 @@ public class Attendance {
     @Column
     private LocalDate date;
     @Column
-    private boolean isEntered;
+    private boolean entered;
     @Column
-    private boolean isExited;
+    private boolean exited;
     @Column
-    private boolean isAbsent;
+    private boolean absented;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "child_id")
     private Child child;
 
     @Builder
     private Attendance (boolean isEntered, boolean isExited, boolean isAbsent, Child child){
-        this.isEntered = isEntered;
-        this.isExited = isExited;
-        this.isAbsent = isAbsent;
+        this.entered = isEntered;
+        this.exited = isExited;
+        this.absented = isAbsent;
         this.child = child;
         this.date = LocalDate.now();
     }
@@ -50,13 +50,13 @@ public class Attendance {
     }
 
     public void enter(){
-        isEntered = !isEntered;
+        entered = !entered;
     }
 
     public void exit(){
-        isExited = !isExited;
+        exited = !exited;
     }
     public void absented(){
-        isAbsent = !isAbsent;
+        absented = !absented;
     }
 }

--- a/src/main/java/com/sparta/finalproject/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/com/sparta/finalproject/domain/attendance/repository/AttendanceRepository.java
@@ -1,10 +1,15 @@
 package com.sparta.finalproject.domain.attendance.repository;
 
 import com.sparta.finalproject.domain.attendance.entity.Attendance;
+import com.sparta.finalproject.domain.child.entity.Child;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     Attendance findByChildIdAndDate(Long childId, LocalDate date);
+    Attendance findByChildAndDate(Child child, LocalDate date);
+    Long countByChild_Classroom_IdAndDateAndEnteredIsTrue(Long classroomId, LocalDate date);
+    Long countByChild_Classroom_IdAndDateAndEnteredIsFalse(Long classroomId, LocalDate date);
+    Long countByChild_Classroom_IdAndDateAndExitedIsTrue(Long classroomId, LocalDate date);
 }

--- a/src/main/java/com/sparta/finalproject/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/com/sparta/finalproject/domain/attendance/repository/AttendanceRepository.java
@@ -12,4 +12,7 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     Long countByChild_Classroom_IdAndDateAndEnteredIsTrue(Long classroomId, LocalDate date);
     Long countByChild_Classroom_IdAndDateAndEnteredIsFalse(Long classroomId, LocalDate date);
     Long countByChild_Classroom_IdAndDateAndExitedIsTrue(Long classroomId, LocalDate date);
+    Long countByDateAndEnteredIsTrue(LocalDate now);
+    Long countByDateAndEnteredIsFalse(LocalDate now);
+    Long countByDateAndExitedIsTrue(LocalDate now);
 }

--- a/src/main/java/com/sparta/finalproject/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/com/sparta/finalproject/domain/attendance/service/AttendanceService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,6 +45,7 @@ public class AttendanceService {
         return GlobalResponseDto.of(CustomStatusCode.CHILD_ENTER_CANCEL, EnterResponseDto.of(childAttendance));
     }
 
+    @Transactional
     public GlobalResponseDto childExitModify(Long childId) {
         Attendance childAttendance = attendanceRepository.findByChildIdAndDate(childId, LocalDate.now());
         childAttendance.exit();
@@ -55,10 +55,11 @@ public class AttendanceService {
         return GlobalResponseDto.of(CustomStatusCode.CHILD_EXIT_CANCEL, EnterResponseDto.of(childAttendance));
     }
 
+    @Transactional
     public GlobalResponseDto childAbsentModify(Long childId) {
         Attendance childAttendance = attendanceRepository.findByChildIdAndDate(childId, LocalDate.now());
         childAttendance.absented();
-        if(childAttendance.isAbsent()){
+        if(childAttendance.isAbsented()){
             return GlobalResponseDto.of(CustomStatusCode.CHILD_ABSENT_SUCCESS, EnterResponseDto.of(childAttendance));
         }
         return GlobalResponseDto.of(CustomStatusCode.CHILD_ABSENT_CANCEL, EnterResponseDto.of(childAttendance));

--- a/src/main/java/com/sparta/finalproject/domain/child/controller/ChildController.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/controller/ChildController.java
@@ -2,6 +2,7 @@ package com.sparta.finalproject.domain.child.controller;
 
 import com.sparta.finalproject.domain.child.dto.AttendanceModifyRequestDto;
 import com.sparta.finalproject.domain.child.dto.ChildRequestDto;
+import com.sparta.finalproject.domain.child.entity.ScheduleType;
 import com.sparta.finalproject.domain.child.service.ChildService;
 import com.sparta.finalproject.global.dto.GlobalResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -55,5 +56,22 @@ public class ChildController {
     public GlobalResponseDto attendanceTimeUpdate(@PathVariable Long childId, @RequestBody AttendanceModifyRequestDto requestDto){
         return childService.updateAttendanceTime(childId,requestDto);
     }
+    // 관리자 페이지 전체 시간대 등/하원 조회
+    @GetMapping("manager/schedule")
+    public GlobalResponseDto scheduleManager(@RequestParam(required = false, defaultValue = "ENTER", value = "type") ScheduleType type,
+                                             @RequestParam(required = false, defaultValue = "1", value = "time") int time,
+                                             @RequestParam(required = false, defaultValue = "1", value = "page") int page,
+                                             @RequestParam(required = false, defaultValue = "16", value = "size") int size) {
+        return childService.scheduleManager(type,time,page,size);
+    }
 
+    // 관리자 페이지 반 별 시간대 등/하원 조회
+    @GetMapping("manager/classroom/{classroomId}/schedule")
+    public GlobalResponseDto classroomScheduleManager(@PathVariable Long classroomId,
+                                                      @RequestParam(required = false, defaultValue = "ENTER", value = "type")ScheduleType type,
+                                                      @RequestParam(required = false, defaultValue = "1", value = "time") int time,
+                                                      @RequestParam(required = false, defaultValue = "1", value = "page") int page,
+                                                      @RequestParam(required = false, defaultValue = "16", value = "size") int size) {
+        return childService.classroomScheduleManager(classroomId,type,time,page,size);
+    }
 }

--- a/src/main/java/com/sparta/finalproject/domain/child/controller/ChildController.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/controller/ChildController.java
@@ -57,21 +57,25 @@ public class ChildController {
         return childService.updateAttendanceTime(childId,requestDto);
     }
     // 관리자 페이지 전체 시간대 등/하원 조회
-    @GetMapping("manager/schedule")
-    public GlobalResponseDto scheduleManager(@RequestParam(required = false, defaultValue = "ENTER", value = "type") ScheduleType type,
-                                             @RequestParam(required = false, defaultValue = "1", value = "time") int time,
-                                             @RequestParam(required = false, defaultValue = "1", value = "page") int page,
-                                             @RequestParam(required = false, defaultValue = "16", value = "size") int size) {
-        return childService.scheduleManager(type,time,page,size);
+//    @GetMapping("manager/schedule")
+//    public GlobalResponseDto scheduleManager(@RequestParam(required = false, defaultValue = "ENTER", value = "type") ScheduleType type,
+//                                             @RequestParam(required = false, defaultValue = "1", value = "time") int time,
+//                                             @RequestParam(required = false, defaultValue = "1", value = "page") int page) {
+//        return childService.scheduleManager(type,time,page-1);
+//    }
+
+    // 관리자 페이지 반 별 조회
+    @GetMapping("manager/classroom/{classroomId}")
+    public GlobalResponseDto managerPageFind(@PathVariable Long classroomId){
+        return childService.findManagerPage(classroomId);
     }
 
     // 관리자 페이지 반 별 시간대 등/하원 조회
     @GetMapping("manager/classroom/{classroomId}/schedule")
-    public GlobalResponseDto classroomScheduleManager(@PathVariable Long classroomId,
-                                                      @RequestParam(required = false, defaultValue = "ENTER", value = "type")ScheduleType type,
-                                                      @RequestParam(required = false, defaultValue = "1", value = "time") int time,
-                                                      @RequestParam(required = false, defaultValue = "1", value = "page") int page,
-                                                      @RequestParam(required = false, defaultValue = "16", value = "size") int size) {
-        return childService.classroomScheduleManager(classroomId,type,time,page,size);
+    public GlobalResponseDto scheduleFind(@PathVariable Long classroomId,
+                                          @RequestParam(required = false, defaultValue = "ENTER", value = "type")ScheduleType type,
+                                          @RequestParam(required = false, defaultValue = "1", value = "time") int time,
+                                          @RequestParam(required = false, defaultValue = "1", value = "page") int page) {
+        return childService.findSchedule(classroomId,type,time,page-1);
     }
 }

--- a/src/main/java/com/sparta/finalproject/domain/child/controller/ChildController.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/controller/ChildController.java
@@ -74,8 +74,8 @@ public class ChildController {
     @GetMapping("manager/classroom/{classroomId}/schedule")
     public GlobalResponseDto scheduleFind(@PathVariable Long classroomId,
                                           @RequestParam(required = false, defaultValue = "ENTER", value = "type")ScheduleType type,
-                                          @RequestParam(required = false, defaultValue = "1", value = "time") int time,
+                                          @RequestParam(required = false, defaultValue = "전체시간", value = "dailyEnterTime") String dailyEnterTime,
                                           @RequestParam(required = false, defaultValue = "1", value = "page") int page) {
-        return childService.findSchedule(classroomId,type,time,page-1);
+        return childService.findSchedule(classroomId,type,dailyEnterTime,page-1);
     }
 }

--- a/src/main/java/com/sparta/finalproject/domain/child/dto/AttendanceModifyRequestDto.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/dto/AttendanceModifyRequestDto.java
@@ -2,17 +2,12 @@ package com.sparta.finalproject.domain.child.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor
 public class AttendanceModifyRequestDto {
 
-    @DateTimeFormat(pattern = "HH:mm")
-    private LocalTime dailyEnterTime;
+    private String dailyEnterTime;
 
-    @DateTimeFormat(pattern = "HH:mm")
-    private LocalTime dailyExitTime;
+    private String dailyExitTime;
 }

--- a/src/main/java/com/sparta/finalproject/domain/child/dto/AttendanceModifyResponseDto.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/dto/AttendanceModifyResponseDto.java
@@ -4,19 +4,14 @@ import com.sparta.finalproject.domain.child.entity.Child;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor
 public class AttendanceModifyResponseDto {
 
-    @DateTimeFormat(pattern = "HH:mm")
-    private LocalTime dailyEnterTime;
+    private String dailyEnterTime;
 
-    @DateTimeFormat(pattern = "HH:mm")
-    private LocalTime dailyExitTime;
+    private String dailyExitTime;
 
 
 

--- a/src/main/java/com/sparta/finalproject/domain/child/dto/ChildEnterResponseDto.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/dto/ChildEnterResponseDto.java
@@ -1,6 +1,5 @@
 package com.sparta.finalproject.domain.child.dto;
 
-import com.sparta.finalproject.domain.attendance.entity.Attendance;
 import com.sparta.finalproject.domain.child.entity.Child;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,39 +11,39 @@ public class ChildEnterResponseDto {
 
     private String name;
     private String profileImageUrl;
-    private boolean currentStatus;
+    private String currentStatus;
     private String enterTime;
     private String exitTime;
 
     @Builder
-    private ChildEnterResponseDto(Child child, Attendance attendance, String enterTime, String exitTime){
+    private ChildEnterResponseDto(Child child, String currentStatus , String enterTime, String exitTime){
         this.name = child.getName();
-        this.currentStatus = attendance.isEntered();
+        this.currentStatus = currentStatus;
         this.profileImageUrl = child.getProfileImageUrl();
         this.enterTime = enterTime;
         this.exitTime = exitTime;
     }
 
-    public static ChildEnterResponseDto of(Child child, Attendance attendance){
+    public static ChildEnterResponseDto of(Child child, String currentStatus){
         return ChildEnterResponseDto.builder()
                 .child(child)
-                .attendance(attendance)
+                .currentStatus(currentStatus)
                 .build();
     }
 
-    public static ChildEnterResponseDto of(Child child, Attendance attendance, String enterTime){
+    public static ChildEnterResponseDto of(Child child, String currentStatus, String enterTime){
         return ChildEnterResponseDto.builder()
                 .child(child)
-                .attendance(attendance)
+                .currentStatus(currentStatus)
                 .enterTime(enterTime)
                 .exitTime(null)
                 .build();
     }
 
-    public static ChildEnterResponseDto of(Child child, Attendance attendance, String enterTime, String exitTime){
+    public static ChildEnterResponseDto of(Child child, String currentStatus, String enterTime, String exitTime){
         return ChildEnterResponseDto.builder()
                 .child(child)
-                .attendance(attendance)
+                .currentStatus(currentStatus)
                 .enterTime(enterTime)
                 .exitTime(exitTime)
                 .build();

--- a/src/main/java/com/sparta/finalproject/domain/child/dto/ChildEnterResponseDto.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/dto/ChildEnterResponseDto.java
@@ -1,0 +1,53 @@
+package com.sparta.finalproject.domain.child.dto;
+
+import com.sparta.finalproject.domain.attendance.entity.Attendance;
+import com.sparta.finalproject.domain.child.entity.Child;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class ChildEnterResponseDto {
+
+    private String name;
+    private String profileImageUrl;
+    private boolean currentStatus;
+    private String enterTime;
+    private String exitTime;
+
+    @Builder
+    private ChildEnterResponseDto(Child child, Attendance attendance, String enterTime, String exitTime){
+        this.name = child.getName();
+        this.currentStatus = attendance.isEntered();
+        this.profileImageUrl = child.getProfileImageUrl();
+        this.enterTime = enterTime;
+        this.exitTime = exitTime;
+    }
+
+    public static ChildEnterResponseDto of(Child child, Attendance attendance){
+        return ChildEnterResponseDto.builder()
+                .child(child)
+                .attendance(attendance)
+                .build();
+    }
+
+    public static ChildEnterResponseDto of(Child child, Attendance attendance, String enterTime){
+        return ChildEnterResponseDto.builder()
+                .child(child)
+                .attendance(attendance)
+                .enterTime(enterTime)
+                .exitTime(null)
+                .build();
+    }
+
+    public static ChildEnterResponseDto of(Child child, Attendance attendance, String enterTime, String exitTime){
+        return ChildEnterResponseDto.builder()
+                .child(child)
+                .attendance(attendance)
+                .enterTime(enterTime)
+                .exitTime(exitTime)
+                .build();
+    }
+
+}

--- a/src/main/java/com/sparta/finalproject/domain/child/dto/ChildExitResponseDto.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/dto/ChildExitResponseDto.java
@@ -1,6 +1,5 @@
 package com.sparta.finalproject.domain.child.dto;
 
-import com.sparta.finalproject.domain.attendance.entity.Attendance;
 import com.sparta.finalproject.domain.child.entity.Child;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,39 +11,39 @@ public class ChildExitResponseDto {
 
     private String name;
     private String profileImageUrl;
-    private boolean currentStatus;
+    private String currentStatus;
     private String enterTime;
     private String exitTime;
 
     @Builder
-    private ChildExitResponseDto(Child child, Attendance attendance, String enterTime, String exitTime){
+    private ChildExitResponseDto(Child child, String currentStatus, String enterTime, String exitTime){
         this.name = child.getName();
-        this.currentStatus = attendance.isExited();
+        this.currentStatus = currentStatus;
         this.profileImageUrl = child.getProfileImageUrl();
         this.enterTime = enterTime;
         this.exitTime = exitTime;
     }
 
-    public static ChildExitResponseDto of(Child child, Attendance attendance){
+    public static ChildExitResponseDto of(Child child, String currentStatus){
         return ChildExitResponseDto.builder()
                 .child(child)
-                .attendance(attendance)
+                .currentStatus(currentStatus)
                 .build();
     }
 
-    public static ChildExitResponseDto of(Child child, Attendance attendance, String enterTime){
+    public static ChildExitResponseDto of(Child child, String currentStatus, String enterTime){
         return ChildExitResponseDto.builder()
                 .child(child)
-                .attendance(attendance)
+                .currentStatus(currentStatus)
                 .enterTime(enterTime)
                 .exitTime(null)
                 .build();
     }
 
-    public static ChildExitResponseDto of(Child child, Attendance attendance, String enterTime, String exitTime){
+    public static ChildExitResponseDto of(Child child, String currentStatus, String enterTime, String exitTime){
         return ChildExitResponseDto.builder()
                 .child(child)
-                .attendance(attendance)
+                .currentStatus(currentStatus)
                 .enterTime(enterTime)
                 .exitTime(exitTime)
                 .build();

--- a/src/main/java/com/sparta/finalproject/domain/child/dto/ChildExitResponseDto.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/dto/ChildExitResponseDto.java
@@ -1,0 +1,53 @@
+package com.sparta.finalproject.domain.child.dto;
+
+import com.sparta.finalproject.domain.attendance.entity.Attendance;
+import com.sparta.finalproject.domain.child.entity.Child;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class ChildExitResponseDto {
+
+    private String name;
+    private String profileImageUrl;
+    private boolean currentStatus;
+    private String enterTime;
+    private String exitTime;
+
+    @Builder
+    private ChildExitResponseDto(Child child, Attendance attendance, String enterTime, String exitTime){
+        this.name = child.getName();
+        this.currentStatus = attendance.isExited();
+        this.profileImageUrl = child.getProfileImageUrl();
+        this.enterTime = enterTime;
+        this.exitTime = exitTime;
+    }
+
+    public static ChildExitResponseDto of(Child child, Attendance attendance){
+        return ChildExitResponseDto.builder()
+                .child(child)
+                .attendance(attendance)
+                .build();
+    }
+
+    public static ChildExitResponseDto of(Child child, Attendance attendance, String enterTime){
+        return ChildExitResponseDto.builder()
+                .child(child)
+                .attendance(attendance)
+                .enterTime(enterTime)
+                .exitTime(null)
+                .build();
+    }
+
+    public static ChildExitResponseDto of(Child child, Attendance attendance, String enterTime, String exitTime){
+        return ChildExitResponseDto.builder()
+                .child(child)
+                .attendance(attendance)
+                .enterTime(enterTime)
+                .exitTime(exitTime)
+                .build();
+    }
+
+}

--- a/src/main/java/com/sparta/finalproject/domain/child/dto/ChildRequestDto.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/dto/ChildRequestDto.java
@@ -8,7 +8,6 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 
 @Getter
 @Setter
@@ -21,8 +20,6 @@ public class ChildRequestDto {
     private Gender gender;
     private String significant;
     private MultipartFile image;
-    @DateTimeFormat(pattern = "HH:mm")
-    private LocalTime dailyEnterTime;
-    @DateTimeFormat(pattern = "HH:mm")
-    private LocalTime dailyExitTime;
+    private String dailyEnterTime;
+    private String dailyExitTime;
 }

--- a/src/main/java/com/sparta/finalproject/domain/child/dto/ChildResponseDto.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/dto/ChildResponseDto.java
@@ -1,6 +1,5 @@
 package com.sparta.finalproject.domain.child.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sparta.finalproject.domain.child.entity.Child;
 import com.sparta.finalproject.global.enumType.Gender;
 import lombok.Builder;
@@ -9,7 +8,6 @@ import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 
 @NoArgsConstructor
 @Getter
@@ -17,15 +15,13 @@ public class ChildResponseDto {
     private Long childId;
     private String name;
     private int age;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate birth;
     private Gender gender;
     private String significant;
     private String profileImageUrl;
-    @DateTimeFormat(pattern = "hh:mm")
-    private LocalTime dailyEnterTime;
-    @DateTimeFormat(pattern = "hh:mm")
-    private LocalTime dailyExitTime;
+    private String dailyEnterTime;
+    private String dailyExitTime;
 
     @Builder
     private ChildResponseDto(Child child) {

--- a/src/main/java/com/sparta/finalproject/domain/child/dto/ManagerPageResponseDto.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/dto/ManagerPageResponseDto.java
@@ -1,0 +1,38 @@
+package com.sparta.finalproject.domain.child.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ManagerPageResponseDto {
+
+    private Long totalNumber;
+    private Long enterNumber;
+    private Long notEnterNumber;
+    private Long exitNumber;
+    private List<ChildEnterResponseDto> childEnterResponseDtoList = new ArrayList<>();
+
+    @Builder
+    private ManagerPageResponseDto(Long totalNumber, Long enterNumber, Long notEnterNumber, Long exitNumber, List<ChildEnterResponseDto> childEnterResponseDtoList){
+        this.totalNumber =totalNumber;
+        this.enterNumber = enterNumber;
+        this.notEnterNumber = notEnterNumber;
+        this.exitNumber = exitNumber;
+        this.childEnterResponseDtoList = childEnterResponseDtoList;
+    }
+
+    public static ManagerPageResponseDto of(Long totalNumber, Long enterNumber, Long notEnterNumber, Long exitNumber, List<ChildEnterResponseDto> childEnterResponseDtoList){
+        return ManagerPageResponseDto.builder()
+                .totalNumber(totalNumber)
+                .enterNumber(enterNumber)
+                .notEnterNumber(notEnterNumber)
+                .exitNumber(exitNumber)
+                .childEnterResponseDtoList(childEnterResponseDtoList)
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/finalproject/domain/child/entity/Child.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/entity/Child.java
@@ -7,6 +7,7 @@ import com.sparta.finalproject.domain.parent.dto.ParentProfileModifyRequestDto;
 import com.sparta.finalproject.domain.parent.entity.Parent;
 import com.sparta.finalproject.global.enumType.Gender;
 import com.sparta.finalproject.global.enumType.Role;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,9 +18,9 @@ import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-@Entity(name = "child")
+@Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Child {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,14 +45,6 @@ public class Child {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Classroom classroom;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "parent_id")
-    private Parent parent;
-//
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "kindergarten", nullable = false)
-//    private Kindergarten kindergarten;
 
     @Builder
     public Child(ChildRequestDto requestDto, Classroom classroom, String profileImageUrl) {

--- a/src/main/java/com/sparta/finalproject/domain/child/entity/Child.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/entity/Child.java
@@ -4,19 +4,14 @@ import com.sparta.finalproject.domain.child.dto.AttendanceModifyRequestDto;
 import com.sparta.finalproject.domain.child.dto.ChildRequestDto;
 import com.sparta.finalproject.domain.classroom.entity.Classroom;
 import com.sparta.finalproject.domain.parent.dto.ParentProfileModifyRequestDto;
-import com.sparta.finalproject.domain.parent.entity.Parent;
 import com.sparta.finalproject.global.enumType.Gender;
-import com.sparta.finalproject.global.enumType.Role;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.*;
 import java.time.LocalDate;
-import java.time.LocalTime;
 
 @Entity
 @Getter
@@ -37,9 +32,9 @@ public class Child {
     @Column
     private String significant;
     @Column
-    private LocalTime dailyEnterTime;
+    private String dailyEnterTime;
     @Column
-    private LocalTime dailyExitTime;
+    private String dailyExitTime;
     @Column
     private String profileImageUrl;
 

--- a/src/main/java/com/sparta/finalproject/domain/child/entity/ScheduleType.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/entity/ScheduleType.java
@@ -1,0 +1,5 @@
+package com.sparta.finalproject.domain.child.entity;
+
+public enum ScheduleType {
+    ENTER,EXIT
+}

--- a/src/main/java/com/sparta/finalproject/domain/child/repository/ChildRepository.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/repository/ChildRepository.java
@@ -1,8 +1,11 @@
 package com.sparta.finalproject.domain.child.repository;
 
 import com.sparta.finalproject.domain.child.entity.Child;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,5 +13,9 @@ public interface ChildRepository extends JpaRepository<Child, Long> {
     Optional<Child> findByClassroomIdAndName(Long classroomId, String name);
     Optional<Child> findByClassroomIdAndId(Long classroomId, Long Id);
     List<Child> findAllByClassroomId(Long classroomId);
+
+    Page<Child> findAllByDailyEnterTimeBetween(LocalTime dailyEnterTime, LocalTime dailyExitDate, Pageable pageable);
+    Page<Child> findAllByClassroomIdAndDailyEnterTimeBetween(Long classroomId, LocalTime dailyEnterTime, LocalTime dailyExitDate, Pageable pageable);
+
 }
 

--- a/src/main/java/com/sparta/finalproject/domain/child/repository/ChildRepository.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/repository/ChildRepository.java
@@ -5,7 +5,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,9 +12,10 @@ public interface ChildRepository extends JpaRepository<Child, Long> {
     Optional<Child> findByClassroomIdAndName(Long classroomId, String name);
     Optional<Child> findByClassroomIdAndId(Long classroomId, Long Id);
     List<Child> findAllByClassroomId(Long classroomId);
-    Page<Child> findAllByDailyEnterTimeBetween(LocalTime dailyEnterTime, LocalTime dailyExitDate, Pageable pageable);
-    Page<Child> findAllByDailyExitTimeBetween(LocalTime dailyEnterTime, LocalTime dailyExitDate, Pageable pageable);
-    Page<Child> findAllByClassroomIdAndDailyEnterTimeBetween(Long classroomId, LocalTime dailyEnterTime, LocalTime dailyExitDate, Pageable pageable);
+    Page<Child> findAllByClassroomId(Long classroomId, Pageable pageable);
+    Page<Child> findAllByDailyEnterTime(String dailyEnterTime, Pageable pageable);
+    Page<Child> findAllByClassroomIdAndDailyEnterTime(Long classroomId, String dailyEnterTime, Pageable pageable);
+    Long countByClassroomId(Long classroomId);
 
 }
 

--- a/src/main/java/com/sparta/finalproject/domain/child/repository/ChildRepository.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/repository/ChildRepository.java
@@ -13,8 +13,8 @@ public interface ChildRepository extends JpaRepository<Child, Long> {
     Optional<Child> findByClassroomIdAndName(Long classroomId, String name);
     Optional<Child> findByClassroomIdAndId(Long classroomId, Long Id);
     List<Child> findAllByClassroomId(Long classroomId);
-
     Page<Child> findAllByDailyEnterTimeBetween(LocalTime dailyEnterTime, LocalTime dailyExitDate, Pageable pageable);
+    Page<Child> findAllByDailyExitTimeBetween(LocalTime dailyEnterTime, LocalTime dailyExitDate, Pageable pageable);
     Page<Child> findAllByClassroomIdAndDailyEnterTimeBetween(Long classroomId, LocalTime dailyEnterTime, LocalTime dailyExitDate, Pageable pageable);
 
 }

--- a/src/main/java/com/sparta/finalproject/domain/child/service/ChildService.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/service/ChildService.java
@@ -6,7 +6,9 @@ import com.sparta.finalproject.domain.child.dto.AttendanceModifyResponseDto;
 import com.sparta.finalproject.domain.child.dto.ChildRequestDto;
 import com.sparta.finalproject.domain.child.dto.ChildResponseDto;
 import com.sparta.finalproject.domain.child.entity.Child;
+import com.sparta.finalproject.domain.child.entity.ScheduleType;
 import com.sparta.finalproject.domain.child.repository.ChildRepository;
+import com.sparta.finalproject.domain.classroom.dto.ClassroomResponseDto;
 import com.sparta.finalproject.domain.classroom.entity.Classroom;
 import com.sparta.finalproject.domain.classroom.repository.ClassroomRepository;
 import com.sparta.finalproject.global.dto.GlobalResponseDto;
@@ -15,10 +17,16 @@ import com.sparta.finalproject.global.response.exceptionType.ChildException;
 import com.sparta.finalproject.global.response.exceptionType.ClassroomException;
 import com.sparta.finalproject.infra.s3.S3Service;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,29 +44,29 @@ public class ChildService {
         Classroom classroom = classroomRepository.findById(classroomId).orElseThrow(
                 () -> new ChildException(CustomStatusCode.CHILD_NOT_FOUND));
         String profileImageUrl = s3Service.upload(childRequestDto.getImage(), "profile-image");
-        Child child = childRepository.save(Child.of(childRequestDto,classroom, profileImageUrl));
-        return GlobalResponseDto.of(CustomStatusCode.ADD_CHILD_SUCCESS,ChildResponseDto.of(child));
+        Child child = childRepository.save(Child.of(childRequestDto, classroom, profileImageUrl));
+        return GlobalResponseDto.of(CustomStatusCode.ADD_CHILD_SUCCESS, ChildResponseDto.of(child));
     }
 
     //반별 아이 프로필 선택 조회
     @Transactional
     public GlobalResponseDto findChild(Long classroomId, Long childId) {
-        Child child = childRepository.findByClassroomIdAndId(classroomId,childId).orElseThrow(
+        Child child = childRepository.findByClassroomIdAndId(classroomId, childId).orElseThrow(
                 () -> new ChildException(CustomStatusCode.CHILD_NOT_FOUND));
-        return GlobalResponseDto.of(CustomStatusCode.FIND_CHILD_SUCCESS,ChildResponseDto.of(child));
+        return GlobalResponseDto.of(CustomStatusCode.FIND_CHILD_SUCCESS, ChildResponseDto.of(child));
     }
 
     //반별 아이 프로필 수정
     @Transactional
-    public GlobalResponseDto modifyChild(Long classroomId, Long childId, ChildRequestDto childRequestDto) throws IOException{
-        Child child = childRepository.findByClassroomIdAndId(classroomId,childId).orElseThrow(
+    public GlobalResponseDto modifyChild(Long classroomId, Long childId, ChildRequestDto childRequestDto) throws IOException {
+        Child child = childRepository.findByClassroomIdAndId(classroomId, childId).orElseThrow(
                 () -> new ChildException(CustomStatusCode.CHILD_NOT_FOUND));
         Classroom classroom = classroomRepository.findById(classroomId).orElseThrow(
                 () -> new ClassroomException(CustomStatusCode.CLASSROOM_NOT_FOUND)
         );
         String profileImageUrl = s3Service.upload(childRequestDto.getImage(), "profile-image");
-        child.update(childRequestDto, classroom,profileImageUrl);
-        return GlobalResponseDto.of(CustomStatusCode.MODIFY_CHILD_SUCCESS,ChildResponseDto.of(child));
+        child.update(childRequestDto, classroom, profileImageUrl);
+        return GlobalResponseDto.of(CustomStatusCode.MODIFY_CHILD_SUCCESS, ChildResponseDto.of(child));
     }
 
     //반별 아이 한명 검색
@@ -67,7 +75,7 @@ public class ChildService {
         Child child = childRepository.findByClassroomIdAndName(classroomId, name).orElseThrow(
                 () -> new ChildException(CustomStatusCode.CHILD_NOT_FOUND)
         );
-        return GlobalResponseDto.of(CustomStatusCode.SEARCH_CHILD_SUCCESS,ChildResponseDto.of(child));
+        return GlobalResponseDto.of(CustomStatusCode.SEARCH_CHILD_SUCCESS, ChildResponseDto.of(child));
     }
 
     public GlobalResponseDto findChildren(Long classroomId) {
@@ -84,5 +92,77 @@ public class ChildService {
         );
         child.update(requestDto);
         return GlobalResponseDto.of(CustomStatusCode.UPDATE_CHILD_ATTENDANCE_TIME_SUCCESS, AttendanceModifyResponseDto.from(child));
+    }
+
+    // 관리자 페이지 "전체" 시간대 등,하원 조회
+    public GlobalResponseDto scheduleManager(ScheduleType type, int time, int page, int size) {
+        Sort.Direction direction = Sort.Direction.ASC;
+        if (type == ScheduleType.EXIT) {
+            direction = Sort.Direction.DESC;
+        }
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, "time"));
+
+        LocalTime dailyEnterTime;
+        LocalTime dailyExitDate;
+        if (time == 1) {
+            // 전체 시간대
+            dailyEnterTime = LocalTime.MIN;
+            dailyExitDate = LocalTime.MAX;
+        } else if (time == 2) {
+            // 7:00~8:00
+            dailyEnterTime = LocalTime.of(7, 0, 0);
+            dailyExitDate = LocalTime.of(8, 0, 0);
+        } else if (time == 3) {
+            // 8:00~9:00
+            dailyEnterTime = LocalTime.of(8, 0, 0);
+            dailyExitDate = LocalTime.of(9, 0, 0);
+        } else {
+            // 9:00~10:00
+            dailyEnterTime = LocalTime.of(9, 0, 0);
+            dailyExitDate = LocalTime.of(10, 0, 0);
+        }
+
+        Page<Child> childPage = childRepository.findAllByDailyEnterTimeBetween(dailyEnterTime, dailyExitDate, pageable);
+        List<ChildResponseDto> childResponseDto = new ArrayList<>();
+        for (Child child : childPage) {
+            childResponseDto.add(ChildResponseDto.of(child));
+        }
+        return GlobalResponseDto.of(CustomStatusCode.MODIFY_CHILD_SUCCESS, ClassroomResponseDto.of(childResponseDto));
+    }
+
+    // 관리자 페이지 "반 별" 시간대 등/하원 조회
+    public GlobalResponseDto classroomScheduleManager(Long classroomId, ScheduleType type, int time, int page, int size) {
+        Sort.Direction direction = Sort.Direction.ASC;
+        if (type == ScheduleType.EXIT) {
+            direction = Sort.Direction.DESC;
+        }
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, "time"));
+
+        LocalTime dailyEnterTime;
+        LocalTime dailyExitDate;
+        if (time == 1) {
+            // 전체 시간대
+            dailyEnterTime = LocalTime.MIN;
+            dailyExitDate = LocalTime.MAX;
+        } else if (time == 2) {
+            // 7:00~8:00
+            dailyEnterTime = LocalTime.of(7, 0, 0);
+            dailyExitDate = LocalTime.of(8, 0, 0);
+        } else if (time == 3) {
+            // 8:00~9:00
+            dailyEnterTime = LocalTime.of(8, 0, 0);
+            dailyExitDate = LocalTime.of(9, 0, 0);
+        } else {
+            // 9:00~10:00
+            dailyEnterTime = LocalTime.of(9, 0, 0);
+            dailyExitDate = LocalTime.of(10, 0, 0);
+        }
+
+        Page<Child> childPage = childRepository.findAllByClassroomIdAndDailyEnterTimeBetween(classroomId, dailyEnterTime, dailyExitDate, pageable);
+        List<ChildResponseDto> childResponseDto = new ArrayList<>();
+        for (Child child : childPage) {
+            childResponseDto.add(ChildResponseDto.of(child));
+        }
+        return GlobalResponseDto.of(CustomStatusCode.MODIFY_CHILD_SUCCESS, ClassroomResponseDto.of(childResponseDto));
     }
 }

--- a/src/main/java/com/sparta/finalproject/domain/classroom/dto/ClassroomResponseDto.java
+++ b/src/main/java/com/sparta/finalproject/domain/classroom/dto/ClassroomResponseDto.java
@@ -33,6 +33,12 @@ public class ClassroomResponseDto {
                 .build();
     }
 
+    public static ClassroomResponseDto of(List<ChildResponseDto> children) {
+        return ClassroomResponseDto.builder()
+                .children(children)
+                .build();
+    }
+
     public static ClassroomResponseDto of(Long classId,List<ChildResponseDto> children){
         return ClassroomResponseDto.builder()
                 .classId(classId)

--- a/src/main/java/com/sparta/finalproject/global/enumType/CurrentStatus.java
+++ b/src/main/java/com/sparta/finalproject/global/enumType/CurrentStatus.java
@@ -1,0 +1,17 @@
+package com.sparta.finalproject.global.enumType;
+
+import lombok.Getter;
+
+@Getter
+public enum CurrentStatus {
+    ENTERED("등원"),
+    NOT_ENTERED("미등원"),
+    EXITED("하원"),
+    NOT_EXITED("미하원");
+    String currentStatus;
+
+    CurrentStatus(String currentStatus) {
+        this.currentStatus = currentStatus;
+    }
+
+}

--- a/src/main/java/com/sparta/finalproject/global/response/CustomStatusCode.java
+++ b/src/main/java/com/sparta/finalproject/global/response/CustomStatusCode.java
@@ -33,7 +33,7 @@ public enum CustomStatusCode {
 
     // child 관련
     ADD_CHILD_SUCCESS(200, "아이 정보가 생성되었습니다."),
-    FIND_CHILDREN_SUCCESS(200, "반 별 아이들 목록이 로드되었습니다."),
+    FIND_CHILDREN_SUCCESS(200, "아이들 목록이 로드되었습니다."),
     FIND_CHILD_SUCCESS(200, "아이 정보가 로드되었습니다."),
     MODIFY_CHILD_SUCCESS(200, "아이 정보가 수정되었습니다."),
     SEARCH_CHILD_SUCCESS(200, "검색한 아이 정보가 로드되었습니다."),
@@ -56,6 +56,10 @@ public enum CustomStatusCode {
     // absent 관련
     CREATE_ABSENT_SUCCESS(200, "결석 신청이 완료되었습니다. "),
     DELETE_ABSENT_SUCCESS(200, "결석 신청이 취소되었습니다. "),
+
+    // Schedule 관련
+    LOAD_MANAGER_PAGE_SUCCESS(200, "관리자 페이지가 로드되었습니다."),
+    FIND_SCHEDULE_SUCCESS(200, "등하원 기록 조회에 성공했습니다."),
 
     // exception
     CLASSROOM_NOT_FOUND(400, "반을 찾을 수 없습니다."),

--- a/src/main/java/com/sparta/finalproject/global/response/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/finalproject/global/response/GlobalExceptionHandler.java
@@ -49,6 +49,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.ok(GlobalResponseDto.of(statusCode));
     }
 
+    @ExceptionHandler(DateTimeException.class)
+    public ResponseEntity<GlobalResponseDto> handleChildException(DateTimeException ex){
+        CustomStatusCode statusCode = ex.getStatusCode();
+        log.error(statusCode.getMessage());
+        return ResponseEntity.ok(GlobalResponseDto.of(statusCode));
+    }
+
     @ExceptionHandler(GlobalException.class)
     public ResponseEntity<GlobalResponseDto> handleGlobalException(GlobalException ex){
         CustomStatusCode statusCode = ex.getStatusCode();

--- a/src/main/java/com/sparta/finalproject/global/response/exceptionType/DateTimeException.java
+++ b/src/main/java/com/sparta/finalproject/global/response/exceptionType/DateTimeException.java
@@ -1,0 +1,10 @@
+package com.sparta.finalproject.global.response.exceptionType;
+
+import com.sparta.finalproject.global.response.CustomStatusCode;
+
+public class DateTimeException extends GlobalException{
+
+    public DateTimeException(CustomStatusCode statusCode){
+        super(statusCode);
+    }
+}


### PR DESCRIPTION
## 📕 관리자 페이지 기능 구현

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 반을 눌렀을 때는 날짜 / 총원 / 등원 인원 / 미 등원 인원 / 하원 인원과 아이들 정보를 모두 반환
- [x] 그 아래 등원 / 하원 / 시간을 눌렀을 때는 해당 카테고리에 해당하는 아이들 정보만 반환
- [x] 등원 / 하원 처리 버튼을 누르면 해당 내용이 DB에 즉시 반영 
- [x] 페이지네이션 

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
등원 / 하원 처리 버튼을 누를 경우 카카오 알림이 가는 기능은 추후에 기능 구현 필요
Resp;ves: #9 #10 #11 
Ref: #51 