### PR TITLE
Fix: 아이 프로필 수정 시 기존 프로필을 그대로 사용하면 프로필 수정이 되지 않던 오류 수정

### DIFF
--- a/src/main/java/com/sparta/finalproject/domain/child/service/ChildService.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/service/ChildService.java
@@ -25,6 +25,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -89,8 +90,13 @@ public class ChildService {
                 () -> new ChildException(CustomStatusCode.CHILD_NOT_FOUND));
         Classroom classroom = classroomRepository.findById(classroomId).orElseThrow(
                 () -> new ClassroomException(CustomStatusCode.CLASSROOM_NOT_FOUND));
-        String profileImageUrl = s3Service.upload(childRequestDto.getImage(), "profile-image");
-
+        MultipartFile profileImage = childRequestDto.getImage();
+        String profileImageUrl;
+        if(profileImage.isEmpty()){
+            profileImageUrl = null;
+        } else {
+            profileImageUrl = s3Service.upload(profileImage, "profile-image");
+        }
         if (childRequestDto.getParentId() != null) {
             User parent = userRepository.findById(childRequestDto.getParentId()).orElseThrow(
                     () -> new UserException(CustomStatusCode.USER_NOT_FOUND));

--- a/src/main/java/com/sparta/finalproject/domain/child/service/ChildService.java
+++ b/src/main/java/com/sparta/finalproject/domain/child/service/ChildService.java
@@ -91,10 +91,8 @@ public class ChildService {
         Classroom classroom = classroomRepository.findById(classroomId).orElseThrow(
                 () -> new ClassroomException(CustomStatusCode.CLASSROOM_NOT_FOUND));
         MultipartFile profileImage = childRequestDto.getImage();
-        String profileImageUrl;
-        if(profileImage.isEmpty()){
-            profileImageUrl = null;
-        } else {
+        String profileImageUrl = child.getProfileImageUrl();
+        if(!profileImage.isEmpty()){
             profileImageUrl = s3Service.upload(profileImage, "profile-image");
         }
         if (childRequestDto.getParentId() != null) {


### PR DESCRIPTION
## 📕 아이 프로필 수정 시 기존 프로필을 그대로 사용하면 프로필 수정이 되지 않던 오류 수정

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 기존 프로필 사용 시 null을 보내도록 하여 null이면 기존 프로필을 유지하도록 하는 로직 추가

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
x