### PR TITLE
Feat: 멤버 관리 페이지 조회 기능 추가

### DIFF
--- a/src/main/java/com/sparta/finalproject/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/finalproject/domain/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.sparta.finalproject.domain.user.dto.TeacherModifyRequestDto;
 import com.sparta.finalproject.domain.user.dto.TeacherProfileModifyRequestDto;
 import com.sparta.finalproject.domain.user.service.UserService;
 import com.sparta.finalproject.global.dto.GlobalResponseDto;
+import com.sparta.finalproject.global.enumType.UserRoleEnum;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -89,5 +90,14 @@ public class UserController {
     @DeleteMapping("user/{userId}/authenticate")
     public GlobalResponseDto userReject(@PathVariable Long userId, @AuthenticationPrincipal UserDetailsImpl userDetails){
         return userService.rejectUser(userId, userDetails.getUser());
+    }
+
+    @GetMapping("kindergarten/{kindergartenId}/user_role/{userRole}")
+    public GlobalResponseDto memberPageFind(@PathVariable Long kindergartenId,
+                                            @PathVariable UserRoleEnum userRole,
+                                            @RequestParam int page,
+                                            @RequestParam int size,
+                                            @AuthenticationPrincipal UserDetailsImpl userDetails){
+        return userService.findMemberPage(kindergartenId, userRole, page, size, userDetails.getUser());
     }
 }

--- a/src/main/java/com/sparta/finalproject/domain/user/dto/MemberPageResponseDto.java
+++ b/src/main/java/com/sparta/finalproject/domain/user/dto/MemberPageResponseDto.java
@@ -1,0 +1,36 @@
+package com.sparta.finalproject.domain.user.dto;
+
+import com.sparta.finalproject.global.enumType.UserRoleEnum;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Setter
+public class MemberPageResponseDto {
+    private UserRoleEnum userRole;
+    private Long memberCount;
+    private List<MemberResponseDto> memberList;
+    private List<MemberResponseDto> earlyMemberList;
+
+    @Builder
+    private MemberPageResponseDto(UserRoleEnum userRole, Long memberCount, List<MemberResponseDto> memberList, List<MemberResponseDto> earlyMemberList){
+        this.userRole = userRole;
+        this.memberCount = memberCount;
+        this.memberList = memberList;
+        this.earlyMemberList = earlyMemberList;
+    }
+
+    public static MemberPageResponseDto of(UserRoleEnum userRole,Long teacherCount, List<MemberResponseDto> memberList, List<MemberResponseDto> earlyMemberList){
+        return MemberPageResponseDto.builder()
+                .userRole(userRole)
+                .memberCount(teacherCount)
+                .memberList(memberList)
+                .earlyMemberList(earlyMemberList)
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/finalproject/domain/user/dto/MemberResponseDto.java
+++ b/src/main/java/com/sparta/finalproject/domain/user/dto/MemberResponseDto.java
@@ -1,0 +1,30 @@
+package com.sparta.finalproject.domain.user.dto;
+
+import com.sparta.finalproject.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MemberResponseDto {
+
+    private Long id;
+    private String name;
+    private String profileImageUrl;
+
+    @Builder
+    private MemberResponseDto(User user){
+        this.id = user.getId();
+        this.name = user.getName();
+        this.profileImageUrl = user.getProfileImageUrl();
+    }
+
+    public static MemberResponseDto of(User user){
+        return MemberResponseDto.builder()
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/finalproject/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/finalproject/domain/user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package com.sparta.finalproject.domain.user.repository;
 
 import com.sparta.finalproject.domain.user.entity.User;
 import com.sparta.finalproject.global.enumType.UserRoleEnum;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -13,4 +15,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findBykakaoId(Long id);
     List<User> findAllByRole(UserRoleEnum role);
     List<User> findByRoleAndNameContaining(UserRoleEnum userRoleEnum,String name);
+    List<User> findAllByRoleAndKindergartenId(UserRoleEnum role, Long id);
+    Page<User> findAllByRoleAndKindergartenId(UserRoleEnum role, Long id, Pageable pageable);
+    Long countAllByRoleAndKindergartenId(UserRoleEnum role, Long id);
 }

--- a/src/main/java/com/sparta/finalproject/global/response/CustomStatusCode.java
+++ b/src/main/java/com/sparta/finalproject/global/response/CustomStatusCode.java
@@ -27,6 +27,7 @@ public enum CustomStatusCode {
     PROFILE_INFO_CHANGE_SUCCESS(200, "프로필 정보 수정 완료."),
     MODIFY_CLASSROOM_TEACHER_SUCCESS(200, "담임 선생님이 설정되었습니다."),
     USER_REJECTED(200, "회원 가입 요청이 거절되었습니다."),
+    FIND_MEMBER_PAGE_SUCCESS(200, "멤버 관리 페이지가 조회되었습니다."),
 
     USER_NOT_FOUND(400, "사용자를 찾을 수 없습니다."),
     DIFFERENT_ROLE(400, "권한이 없습니다."),


### PR DESCRIPTION
## 📕 멤버 관리 페이지 조회 기능 추가

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

#100 이슈 내 체크 사항 1, 2, 3, 4, 5 성공

- [x] 멤버 관리 탭을 누르면 선생님 목록과 선생님 가입 신청 목록을 반환
- [x] 멤버 관리 탭 안에서 선생님을 누르면 선생님 목록과 선생님 가입 신청 목록을 반환
- [x] 멤버 관리 탭 안에서 학부모를 누르면 학부모 목록과 학부모 가입 신청 목록을 반환
- [x] 선생님 목록과 학부모 목록은 페이지네이션하여 반환
- [x] 반환된 사용자 목록이 학부모인지 선생님인지를 알려주는 변수 반환

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
x
