### PR TITLE
Feat : Redis를 통한 RefreshToken관리 / RefreshToken을 통한 AccessToken을 재발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+//    implementation 'org.springframework.boot:spring-boot-starter-data-redis:2.3.1.RELEASE'
 
     implementation group: 'org.json', name: 'json', version: '20220924'
 

--- a/src/main/java/com/sparta/finalproject/domain/jwt/AccessTokenReissuanceController.java
+++ b/src/main/java/com/sparta/finalproject/domain/jwt/AccessTokenReissuanceController.java
@@ -1,0 +1,22 @@
+//package com.sparta.finalproject.domain.jwt;
+//
+//import com.sparta.finalproject.domain.security.UserDetailsImpl;
+//import com.sparta.finalproject.global.dto.GlobalResponseDto;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.security.core.annotation.AuthenticationPrincipal;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//import javax.servlet.http.HttpServletResponse;
+//
+//@RestController
+//@RequiredArgsConstructor
+//public class AccessTokenReissuanceController {
+//
+//    private final AccessTokenReissuanceService accessTokenReissuanceService;
+//
+//    @PostMapping("newAccessToken")
+//    public GlobalResponseDto accessTokenReissuance(@AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response) {
+//
+//        return accessTokenReissuanceService.reissuanceAccessToken(userDetails.getUser(), response);
+//    }
+//}

--- a/src/main/java/com/sparta/finalproject/domain/jwt/AccessTokenReissuanceService.java
+++ b/src/main/java/com/sparta/finalproject/domain/jwt/AccessTokenReissuanceService.java
@@ -1,0 +1,39 @@
+//package com.sparta.finalproject.domain.jwt;
+//
+//import com.sparta.finalproject.domain.user.entity.User;
+//import com.sparta.finalproject.global.dto.GlobalResponseDto;
+//import com.sparta.finalproject.global.response.CustomStatusCode;
+//import com.sparta.finalproject.global.response.exceptionType.UserException;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.stereotype.Service;
+//import org.springframework.transaction.annotation.Transactional;
+//import javax.servlet.http.Cookie;
+//import javax.servlet.http.HttpServletResponse;
+//
+//@Service
+//@RequiredArgsConstructor
+//public class AccessTokenReissuanceService {
+//
+//    private final JwtUtil jwtUtil;
+//
+//    private final RefreshTokenRepository refreshTokenRepository;
+//
+//    @Transactional
+//    public GlobalResponseDto reissuanceAccessToken(User user, HttpServletResponse response) {
+//
+//        RefreshToken isRefreshToken = refreshTokenRepository.findByKakaoId(user.getKakaoId()).orElseThrow(
+//                () -> new UserException(CustomStatusCode.REFRESH_TOKEN_NOT_FOUND));
+//
+//        if(isRefreshToken != null) {
+//
+//            String newAccessToken = jwtUtil.createToken(user.getName(), user.getRole());
+//
+//            Cookie cookie = new Cookie(JwtUtil.AUTHORIZATION_HEADER, newAccessToken.substring(7));
+//            cookie.setPath("/");
+//
+//            response.addCookie(cookie);
+//        }
+//
+//        return GlobalResponseDto.from(CustomStatusCode.ACCESS_TOKEN_REISSUANCE_SUCCESS);
+//    }
+//}

--- a/src/main/java/com/sparta/finalproject/domain/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/finalproject/domain/jwt/JwtUtil.java
@@ -14,7 +14,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import java.security.Key;

--- a/src/main/java/com/sparta/finalproject/domain/jwt/RefreshToken.java
+++ b/src/main/java/com/sparta/finalproject/domain/jwt/RefreshToken.java
@@ -1,0 +1,21 @@
+//package com.sparta.finalproject.domain.jwt;
+//
+//import lombok.Getter;
+//import org.springframework.data.annotation.Id;
+//import org.springframework.data.redis.core.RedisHash;
+//import org.springframework.data.redis.core.index.Indexed;
+//
+//@Getter
+//@RedisHash(value = "refreshToken", timeToLive =14 * 24 * 60 * 60 * 1000L)
+//public class RefreshToken {
+//
+//    @Id
+//    private String refreshToken;
+//    @Indexed
+//    private Long kakaoId;
+//
+//    public RefreshToken(String refreshToken, Long kakaoId) {
+//        this.refreshToken = refreshToken;
+//        this.kakaoId = kakaoId;
+//    }
+//}

--- a/src/main/java/com/sparta/finalproject/domain/jwt/RefreshTokenRepository.java
+++ b/src/main/java/com/sparta/finalproject/domain/jwt/RefreshTokenRepository.java
@@ -1,0 +1,9 @@
+//package com.sparta.finalproject.domain.jwt;
+//
+//import org.springframework.data.repository.CrudRepository;
+//import java.util.Optional;
+//
+//public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+//
+//    Optional<RefreshToken> findByKakaoId(Long kakaoId);
+//}

--- a/src/main/java/com/sparta/finalproject/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/finalproject/domain/user/service/UserService.java
@@ -7,6 +7,8 @@ import com.sparta.finalproject.domain.child.dto.SidebarChildrenInfo;
 import com.sparta.finalproject.domain.child.entity.Child;
 import com.sparta.finalproject.domain.child.repository.ChildRepository;
 import com.sparta.finalproject.domain.jwt.JwtUtil;
+//import com.sparta.finalproject.domain.jwt.RefreshToken;
+//import com.sparta.finalproject.domain.jwt.RefreshTokenRepository;
 import com.sparta.finalproject.domain.kindergarten.dto.KindergartenResponseDto;
 import com.sparta.finalproject.domain.kindergarten.entity.Kindergarten;
 import com.sparta.finalproject.domain.kindergarten.repository.KindergartenRepository;
@@ -35,12 +37,14 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
-
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.sparta.finalproject.global.enumType.UserRoleEnum.*;
@@ -62,6 +66,8 @@ public class UserService {
 
     private final ChildRepository childRepository;
 
+//    private final RefreshTokenRepository refreshTokenRepository;
+
     @Transactional
     public GlobalResponseDto loginUser(String code, HttpServletRequest request, HttpServletResponse response) throws JsonProcessingException {
 
@@ -73,8 +79,21 @@ public class UserService {
         kakaoUser.putAccessToken(accessToken);
 
         String createToken = jwtUtil.createToken(kakaoUser.getName(), kakaoUser.getRole());
-
         response.addHeader(JwtUtil.AUTHORIZATION_HEADER, createToken);
+
+//        Cookie cookie = new Cookie(JwtUtil.AUTHORIZATION_HEADER, createToken.substring(7));
+//        cookie.setPath("/");
+//        response.addCookie(cookie);
+
+//        Optional<RefreshToken> isRefreshToken = refreshTokenRepository.findByKakaoId(kakaoUser.getKakaoId());
+//        if(isRefreshToken.isEmpty()) {
+//
+//            String createRefreshToken = UUID.randomUUID().toString();
+//
+//            RefreshToken refreshToken = new RefreshToken(createRefreshToken, kakaoUser.getKakaoId());
+//
+//            refreshTokenRepository.save(refreshToken);
+//        }
 
         if(EARLY_USER.equals(kakaoUser.getRole())) {
 

--- a/src/main/java/com/sparta/finalproject/global/response/CustomStatusCode.java
+++ b/src/main/java/com/sparta/finalproject/global/response/CustomStatusCode.java
@@ -14,6 +14,8 @@ public enum CustomStatusCode {
     TOKEN_NOT_FOUND(400, "토큰이 없습니다."),
     UNAUTHORIZED_USER(400, "인가되지 않은 사용자입니다."),
     USER_AUTHORIZED(200, "회원 가입 요청이 승인되었습니다."),
+    REFRESH_TOKEN_NOT_FOUND(400,"유효한 RefreshToken이 없습니다"),
+    ACCESS_TOKEN_REISSUANCE_SUCCESS(200, "AccessToken 재발급이 완료 되었습니다."),
 
     //User 관련
     SIGN_UP_SUCCESS(200, "회원 가입에 성공했습니다."),


### PR DESCRIPTION
## 📕 제목 
RefreshToken을 통해서 AccessToken을 재발급 받도록 구현

## 📗 작업 내용
- RefreshToken을 Redis를 통해서 관리 하도록 구현 및 적용
- RefreshToken을 통해서 AccessToken을 재발급 받도록 구현

> 구현 내용 및 작업 했던 내역

- [x] EC2 ubuntu서버에 Redis 구현 및 설정
- [x] RefreshToken을 Redis에서 관리 및 저장 되도록 구현
- [x] AccessToken 만료 시 RefreshToken을 통해서 재발급 받도록 구현 

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Redis, RefreshToken, AccessToken을 프론트엔드와 백엔드가 서로 어떤 flow를 통해서 로그인을 유지 시키는지 생각 해보기
